### PR TITLE
Use HTTPS transport in repository URL

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -9,4 +9,4 @@ license = GPLv3+
 bundle_id = vu.lux.olpc.Maze
 summary = Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path, or you can also play with a friend!
 max_participants = 6
-repository = git@github.com:godiard/maze-activity.git
+repository = https://github.com/godiard/maze-activity


### PR DESCRIPTION
Fixes `git clone` on systems that don't have an SSH key for github.com.
