### PR TITLE
Allow escape from FinishWindow

### DIFF
--- a/game.py
+++ b/game.py
@@ -798,3 +798,6 @@ class FinishWindow(Gtk.Window):
     def __key_press_event_cb(self, window, event):
         if event.keyval == Gdk.KEY_Escape:
             GObject.idle_add(self._game.close_finish_window)
+        elif event.keyval == Gdk.KEY_q and \
+            event.state & Gdk.ModifierType.CONTROL_MASK != 0:
+            self._game._activity.close()

--- a/game.py
+++ b/game.py
@@ -691,6 +691,7 @@ class FinishWindow(Gtk.Window):
         self.set_decorated(False)
         self.set_resizable(False)
         self.connect('realize', self.__realize_cb)
+        self.connect('key-press-event', self.__key_press_event_cb)
 
         grid = Gtk.Grid()
         grid.set_row_spacing(0)
@@ -793,3 +794,7 @@ class FinishWindow(Gtk.Window):
 
     def _harder_button_cb(self, button):
         GObject.idle_add(self._game.harder)
+
+    def __key_press_event_cb(self, window, event):
+        if event.keyval == Gdk.KEY_Escape:
+            GObject.idle_add(self._game.close_finish_window)


### PR DESCRIPTION
Press Escape key to dismiss the "Maze solved!" window,
- use case is for players to see the maze; they can then click on easier or harder buttons in toolbar,
- also useful for screenshots.

Also handle quit shortcut.  The stop button still works, but the dialog prevents the shortcut.
