### PR TITLE
Fix fail to quit [review only]

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -1,21 +1,36 @@
-import threading
+#
+#   sensors.py, Copyright (C) 2014-2016 One Laptop per Child
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 import subprocess
 
 from gi.repository import GObject
-
-GObject.threads_init()
+from gi.repository import Gtk
 
 
 class Accelerometer():
 
-    ACCELEROMETER_DEVICE = '/sys/devices/platform/lis3lv02d/position'
+    DEVICE = '/sys/devices/platform/lis3lv02d/position'
 
     def read_position(self):
         """
-        return x, y, z values or None if no accelerometer is available
+        return [x, y, z] values or [0, 0, 0] if no accelerometer is available
         """
         try:
-            fh = open(self.ACCELEROMETER_DEVICE)
+            fh = open(self.DEVICE)
             string = fh.read()
             xyz = string[1:-2].split(',')
             fh.close()
@@ -26,73 +41,81 @@ class Accelerometer():
 
 class EbookModeDetector(GObject.GObject):
 
-    EBOOK_DEVICE = '/dev/input/event4'
+    DEVICE = '/dev/input/event4'
 
     __gsignals__ = {
         'changed': (GObject.SignalFlags.RUN_FIRST, None, ([bool])), }
 
     def __init__(self):
         GObject.GObject.__init__(self)
-        self._ebook_mode = False
+
         try:
-            fd = open(self.EBOOK_DEVICE, 'rb')
+            self._fp = open(self.DEVICE, 'rb')
         except IOError:
+            self._ebook_mode = False
             return
-        fd.close()
+
+        def _io_in_cb(fp, condition):
+            data = fp.read(16)
+            if data == '':
+                return False
+            if ord(data[10]) == 1:
+                mode = (ord(data[12]) == 1)
+                if mode != self._ebook_mode:
+                    self._ebook_mode = mode
+                    self.emit('changed', self._ebook_mode)
+            return True
+
+        self._sid = GObject.io_add_watch(self._fp, GObject.IO_IN, _io_in_cb)
+
         self._ebook_mode = self._get_initial_value()
-        self._start_reading()
 
     def get_ebook_mode(self):
         return self._ebook_mode
 
     def _get_initial_value(self):
         try:
-            output = subprocess.call(['evtest', '--query', self.EBOOK_DEVICE,
+            output = subprocess.call(['evtest', '--query', self.DEVICE,
                                       'EV_SW', 'SW_TABLET_MODE'])
             # 10 is ebook_mode, 0 is normal
             return (output == 10)
         except:
             return False
 
-    def _start_reading(self):
-        thread = threading.Thread(target=self._read)
-        thread.start()
 
-    def _read(self):
-        fd = open(self.EBOOK_DEVICE, 'rb')
-        for x in range(12):
-            fd.read(1)
-        value = ord(fd.read(1))
-        fd.close()
-        self._ebook_mode = (value == 1)
-        self.emit('changed', self._ebook_mode)
-        # restart
-        GObject.idle_add(self._start_reading)
+def test():
+    window = Gtk.Window(title='test sensors')
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
+                  spacing=20, border_width=20)
+    window.add(box)
+    ebookmode_label = Gtk.Label()
+    box.add(ebookmode_label)
+    accelerometer_label = Gtk.Label()
+    box.add(accelerometer_label)
+    window.connect('destroy', Gtk.main_quit)
+    window.connect('key-press-event', Gtk.main_quit)
 
-# TODO: Move to tests
+    def _changed_cb(ebookdetector, ebook_mode):
+        if ebook_mode:
+            ebookmode_label.set_label('ebook mode')
+        else:
+            ebookmode_label.set_label('laptop mode')
 
-import logging
-from gi.repository import Gtk
-
-
-def log_ebook_mode(detector, ebook_mode):
-    logging.error('Ebook mode %s', ebook_mode)
-
-
-def quit(win, detector):
-    Gtk.main_quit()
-
-
-def main():
-    win = Gtk.Window()
-    win.set_default_size(450, 550)
-    label = Gtk.Label('Put your xo in ebook mode nd in notebook mode')
-    win.add(label)
-    win.show_all()
     ebookdetector = EbookModeDetector()
-    ebookdetector.connect('changed', log_ebook_mode)
-    win.connect('destroy', quit, ebookdetector)
+    _changed_cb(ebookdetector, ebookdetector.get_ebook_mode())
+    ebookdetector.connect('changed', _changed_cb)
+
+    def _timeout_cb():
+        pos = accelerometer.read_position()
+        accelerometer_label.set_label('accelerometer %s' % repr(pos))
+        return True
+
+    accelerometer = Accelerometer()
+    _timeout_cb()
+    GObject.timeout_add(100, _timeout_cb)
+
+    window.show_all()
     Gtk.main()
 
 if __name__ == '__main__':
-    main()
+    test()


### PR DESCRIPTION
For review only, as I'm able to push.

Same problem also affects Chat activity, and @i5o had pending Terminal activity changes.

----

On XO-1.75 and XO-4, the Maze activity process did persist after stop.

Cause was `sensors.EbookModeDetector._read thread`, blocked on `read(2)` of `/dev/input/event4`.  Expected because `thread.daemon` is not `True`.

Did not affect XO-1 or XO-1.5, because `/dev/input/event4` is not readable unless root.

Set `thread.daemon` `True` can fix, but 8d2b8d7 turned it off for reasons none of us can remember.

So

* switch from threading to event loop, using a watch, and handle unexpected end of file by cancelling the watch.

* validate event data, (which avoids a redundant changed signal),

* rewrite test harness, adding accelerometer data to display,

* add copyright and license.