### PR TITLE
Avoid pillow import errors

### DIFF
--- a/game.py
+++ b/game.py
@@ -40,7 +40,7 @@ from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.toolbutton import ToolButton
 
 from maze import Maze, Rectangle
-from player import Player
+from mazeplayer import MazePlayer
 import sensors
 
 
@@ -65,7 +65,7 @@ class MazeGame(Gtk.DrawingArea):
         self.localplayers = []
 
         # start with just one player
-        player = Player(owner)
+        player = MazePlayer(owner)
         self.localplayers.append(player)
         # plus some bonus players (all hidden to start with)
         self.localplayers.extend(player.bonusPlayers())
@@ -471,7 +471,7 @@ class MazeGame(Gtk.DrawingArea):
         if buddy:
             logging.debug("Join: %s - %s", buddy.props.nick,
                           buddy.props.color)
-            player = Player(buddy)
+            player = MazePlayer(buddy)
             player.uid = buddy.get_key()
             self.remoteplayers[buddy.get_key()] = player
             self.allplayers.append(player)

--- a/mazeplayer.py
+++ b/mazeplayer.py
@@ -30,7 +30,7 @@ from sugar3.graphics import style
 from maze import Rectangle
 
 
-class Player:
+class MazePlayer:
     def __init__(self, buddy, look='centre'):
         self.buddy = buddy
         name = buddy.props.nick.decode('utf-8')
@@ -176,8 +176,8 @@ class Player:
     def bonusPlayers(self):
         if self.bonusplayers is None:
             self.bonusplayers = []
-            self.bonusplayers.append(Player(self.buddy, 'left'))
-            self.bonusplayers.append(Player(self.buddy, 'right'))
+            self.bonusplayers.append(MazePlayer(self.buddy, 'left'))
+            self.bonusplayers.append(MazePlayer(self.buddy, 'right'))
 
             count = 1
             for player in self.bonusplayers:


### PR DESCRIPTION
On Debian systems since around 2009, and not yet fixed, the
Jukebox and Maze activities fail to start, and logs contain;

```
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 164, in main
    module = __import__(module_name)
  File "/usr/share/sugar/activities/Jukebox.activity/activity.py", line 51, in <module>
    from player import GstPlayer
  File "/usr/bin/player.py", line 14, in <module>
    from PIL import Image, ImageTk
ImportError: cannot import name ImageTk
```

Underlying cause is another package, `pillow`, which by providing a file `/usr/bin/player.py` overrides our import.

Rather than wait for the other packages to be fixed, just rename our module.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=554906